### PR TITLE
Fixed #246: Added ignores for missing docstrings in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,10 @@ exclude = [
     'doc/*',
     'src/omotes_simulator_core/solver/utils/fluidprop.py',
 ]
-per-file-ignores = ['__init__.py:F401', 'unit_test/*:D100,D104']
+per-file-ignores = [
+    '__init__.py:F401',
+    'unit_test/*:D100,D101,D102,D103,D104,D105,D106',
+]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Added ignores for D100, D101, D102, D103, D104, D105 and D106 for the entire unit_tests folder. This essentially means that a docstring is not required. However, IF a docstring is provided, it will still be linted and should adhere to the coding standards.

see http://www.pydocstyle.org/en/2.1.1/error_codes.html for explanation of error codes