### PR TITLE
Integrated ESDL messages 

### DIFF
--- a/src/omotes_simulator_core/entities/assets/ates_cluster.py
+++ b/src/omotes_simulator_core/entities/assets/ates_cluster.py
@@ -14,6 +14,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """atesCluster class."""
+import logging
 import math
 import os
 
@@ -33,6 +34,8 @@ from omotes_simulator_core.entities.assets.utils import (
     heat_demand_and_temperature_to_mass_flow,
 )
 from omotes_simulator_core.solver.network.assets.production_asset import HeatBoundary
+
+logger = logging.getLogger(__name__)
 
 
 class AtesCluster(AssetAbstract):
@@ -177,6 +180,10 @@ class AtesCluster(AssetAbstract):
             self._set_solver_asset_setpoint()
         else:
             # Print missing setpoints
+            logger.error(
+                f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing.",
+                extra={"esdl_object_id": self.asset_id},
+            )
             raise ValueError(
                 f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing."
             )

--- a/src/omotes_simulator_core/entities/assets/demand_cluster.py
+++ b/src/omotes_simulator_core/entities/assets/demand_cluster.py
@@ -14,6 +14,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """demandCluster class."""
+import logging
+
 from omotes_simulator_core.entities.assets.asset_abstract import AssetAbstract
 from omotes_simulator_core.entities.assets.asset_defaults import (
     DEFAULT_DIAMETER,
@@ -30,6 +32,8 @@ from omotes_simulator_core.entities.assets.utils import (
     heat_demand_and_temperature_to_mass_flow,
 )
 from omotes_simulator_core.solver.network.assets.production_asset import HeatBoundary
+
+logger = logging.getLogger(__name__)
 
 
 class DemandCluster(AssetAbstract):
@@ -71,6 +75,10 @@ class DemandCluster(AssetAbstract):
         # Check if all setpoints are in the setpoints
         if not necessary_setpoints.issubset(setpoints_set):
             # Print missing setpoints
+            logger.error(
+                f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing.",
+                extra={"esdl_object_id": self.asset_id},
+            )
             raise ValueError(
                 f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing."
             )

--- a/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
+++ b/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
@@ -67,7 +67,8 @@ class EsdlAssetObject:
             # Send message to logger
             logger.warning(
                 f"Property {esdl_property_name} is not set for: {self.esdl_asset.name}."
-                + f"Returning default value: {default_value}."
+                + f"Returning default value: {default_value}.",
+                extra={"esdl_object_id": self.get_id()},
             )
             return default_value
         else:
@@ -78,6 +79,10 @@ class EsdlAssetObject:
         for esdl_port in self.esdl_asset.port:
             if esdl_port.profile:
                 return get_data_from_profile(esdl_port.profile[0])
+        logger.error(
+            f"No profile found for asset: {self.esdl_asset.name}",
+            extra={"esdl_object_id": self.get_id()},
+        )
         raise ValueError(f"No profile found for asset: {self.esdl_asset.name}")
 
     def get_supply_temperature(self, port_type: str) -> float:
@@ -85,6 +90,10 @@ class EsdlAssetObject:
         for esdl_port in self.esdl_asset.port:
             if isinstance(esdl_port, self.get_port_type(port_type)):
                 return get_supply_temperature(esdl_port)
+        logger.error(
+            f"No port found with type: {port_type} for asset: {self.esdl_asset.name}",
+            extra={"esdl_object_id": self.get_id()},
+        )
         raise ValueError(f"No port found with type: {port_type} for asset: {self.esdl_asset.name}")
 
     def get_return_temperature(self, port_type: str) -> float:
@@ -92,6 +101,10 @@ class EsdlAssetObject:
         for esdl_port in self.esdl_asset.port:
             if isinstance(esdl_port, self.get_port_type(port_type)):
                 return get_return_temperature(esdl_port)
+        logger.error(
+            f"No port found with type: {port_type} for asset: {self.esdl_asset.name}",
+            extra={"esdl_object_id": self.get_id()},
+        )
         raise ValueError(f"No port found with type: {port_type} for asset: {self.esdl_asset.name}")
 
     def get_port_ids(self) -> list[str]:
@@ -115,6 +128,10 @@ class EsdlAssetObject:
         elif port_type == "Out":
             return esdl.OutPort  # type: ignore [no-any-return]
         else:
+            logger.error(
+                f"Port type not recognized: {port_type} for asset: {self.esdl_asset.name}",
+                extra={"esdl_object_id": self.get_id()},
+            )
             raise ValueError(f"Port type not recognized: {port_type}")
 
     def get_marginal_costs(self) -> float:
@@ -122,13 +139,15 @@ class EsdlAssetObject:
         if self.esdl_asset.costInformation is None:
             logger.warning(
                 f"No cost information found for asset, Marginal costs set to 0 for: "
-                f"{self.esdl_asset.name}"
+                f"{self.esdl_asset.name}",
+                extra={"esdl_object_id": self.get_id()},
             )
             return 0
         if self.esdl_asset.costInformation.marginalCosts is None:
             logger.warning(
                 f"No marginal costs found for asset, Marginal costs set to 0 for: "
-                f"{self.esdl_asset.name}"
+                f"{self.esdl_asset.name}",
+                extra={"esdl_object_id": self.get_id()},
             )
             return 0
         return float(self.esdl_asset.costInformation.marginalCosts.value)

--- a/src/omotes_simulator_core/entities/assets/production_cluster.py
+++ b/src/omotes_simulator_core/entities/assets/production_cluster.py
@@ -32,6 +32,10 @@ from omotes_simulator_core.entities.assets.utils import (
 )
 from omotes_simulator_core.solver.network.assets.production_asset import HeatBoundary
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class ProductionCluster(AssetAbstract):
     """A ProductionCluster represents an asset that produces heat."""
@@ -121,6 +125,11 @@ class ProductionCluster(AssetAbstract):
 
         # Check if the mass flow rate is positive
         if self.controlled_mass_flow < 0.0:
+            logger.error(
+                f"The mass flow rate {self.controlled_mass_flow} of the asset {self.name}"
+                + " is negative.",
+                extra={"esdl_object_id": self.asset_id},
+            )
             raise ValueError(
                 f"The mass flow rate {self.controlled_mass_flow} of the asset {self.name}"
                 + " is negative."
@@ -147,6 +156,10 @@ class ProductionCluster(AssetAbstract):
         """
         # Check if the pressure is positive
         if pressure_supply < 0.0:
+            logger.error(
+                f"The pressure {pressure_supply} of the asset {self.name} can not be negative.",
+                extra={"esdl_object_id": self.asset_id},
+            )
             raise ValueError(
                 f"The pressure {pressure_supply} of the asset {self.name} can not be negative."
             )
@@ -180,6 +193,10 @@ class ProductionCluster(AssetAbstract):
             self._set_heat_demand(setpoints[PROPERTY_HEAT_DEMAND])
         else:
             # Print missing setpoints
+            logger.error(
+                f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing.",
+                extra={"esdl_object_id": self.asset_id},
+            )
             raise ValueError(
                 f"The setpoints {necessary_setpoints.difference(setpoints_set)} are missing."
             )

--- a/src/omotes_simulator_core/entities/utility/influxdb_reader.py
+++ b/src/omotes_simulator_core/entities/utility/influxdb_reader.py
@@ -19,6 +19,9 @@ from esdl.units.conversion import ENERGY_IN_J, POWER_IN_W, convert_to_unit
 import esdl
 from esdl.esdl_handler import EnergySystemHandler
 import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def parse_esdl_profiles(esh: EnergySystemHandler) -> dict[str, pd.DataFrame]:
@@ -72,24 +75,48 @@ def get_data_from_profile(esdl_profile: esdl.InfluxDBProfile) -> pd.DataFrame:
 
     # I do not thing this is required since you set it in mapeditor.
     if time_series_data.end_datetime != esdl_profile.endDate:
+        logger.error(
+            f"The user input profile end datetime: {esdl_profile.endDate} does not match the end"
+            f" datetime in the datbase: {time_series_data.end_datetime} for variable: "
+            f"{esdl_profile.field}",
+            extra={"esdl_object_id": esdl_profile.id},
+        )
         raise RuntimeError(
             f"The user input profile end datetime: {esdl_profile.endDate} does not match the end"
             f" datetime in the datbase: {time_series_data.end_datetime} for variable: "
             f"{esdl_profile.field}"
         )
     if time_series_data.start_datetime != esdl_profile.startDate:
+        logger.error(
+            f"The user input profile start datetime: {esdl_profile.startDate} does not match the"
+            f" start date in the datbase: {time_series_data.start_datetime} for variable: "
+            f"{esdl_profile.field}",
+            extra={"esdl_object_id": esdl_profile.id},
+        )
         raise RuntimeError(
             f"The user input profile start datetime: {esdl_profile.startDate} does not match the"
             f" start date in the datbase: {time_series_data.start_datetime} for variable: "
             f"{esdl_profile.field}"
         )
     if time_series_data.start_datetime != time_series_data.profile_data_list[0][0]:
+        logger.error(
+            f"The profile's variable value for the start datetime: "
+            f"{time_series_data.start_datetime} does not match the start datetime of the"
+            f" profile data: {time_series_data.profile_data_list[0][0]}",
+            extra={"esdl_object_id": esdl_profile.id},
+        )
         raise RuntimeError(
             f"The profile's variable value for the start datetime: "
             f"{time_series_data.start_datetime} does not match the start datetime of the"
             f" profile data: {time_series_data.profile_data_list[0][0]}"
         )
     if time_series_data.end_datetime != time_series_data.profile_data_list[-1][0]:
+        logger.error(
+            f"The profile's variable value for the end datetime: "
+            f"{time_series_data.end_datetime} does not match the end datetime of the"
+            f" profile data: {time_series_data.profile_data_list[-1][0]}",
+            extra={"esdl_object_id": esdl_profile.id},
+        )
         raise RuntimeError(
             f"The profile's variable value for the end datetime: "
             f"{time_series_data.end_datetime} does not match the end datetime of the"

--- a/src/omotes_simulator_core/infrastructure/simulation_manager.py
+++ b/src/omotes_simulator_core/infrastructure/simulation_manager.py
@@ -50,12 +50,18 @@ class SimulationManager:
 
         :return: DataFrame with the result of the simulations
         """
-        # convert ESDL to Heat Network, NetworkController
-        network = HeatNetwork(EsdlEnergySystemMapper(self.esdl).to_entity)
-        controller = EsdlControllerMapper().to_entity(self.esdl)
+        try:
+            # convert ESDL to Heat Network, NetworkController
+            network = HeatNetwork(EsdlEnergySystemMapper(self.esdl).to_entity)
+            controller = EsdlControllerMapper().to_entity(self.esdl)
 
-        worker = NetworkSimulation(network, controller)
-        worker.run(self.config, progress_calback)
+            worker = NetworkSimulation(network, controller)
+            worker.run(self.config, progress_calback)
+        except Exception as error:
+            logger.error(
+                f"Error occured: {error}"
+            )  # Asset ID is not set,  error is reported for the entire ESDL/run
+            raise error
 
         # Run output presenter that iterates over het network (/controller?) and
         # gathers the output into a single data object


### PR DESCRIPTION
Added logging calls so messages are shown forwarded to front-end as ESDL messages. The actual implementation is done in the simulator worker via a logging handler. 

devs should add the asset/object id in a logging call in order to assign messages to a specific asset/object: 

Example: 
`logger.error(f"The value {variable} is not allowed", extra={"esdl_object_id": self.asset_id")`

The current implementation forwards ALL logging messages received by the handler as messages.  

closes #230 