### PR TITLE
Updated create_venv script to check if py3.11 

### DIFF
--- a/ci/win32/create_venv.cmd
+++ b/ci/win32/create_venv.cmd
@@ -4,28 +4,32 @@ rem @echo off
 pushd .
 cd /D "%~dp0"
 
+set VENV_DIR=..\..\venv
+
 py --list | findstr /i /C:"3.11" 
 if %errorlevel% == 0 (
-    echo Python 3.11 found!.
-    py -3.11 -m venv ..\..\venv
+    echo Python 3.11 found!
+    py -3.11 -m venv %VENV_DIR%
 ) else (
-    echo Python 3.11 not found, using installed 3.X version.
-    py -3 -m venv ..\..\venv
+    echo Python 3.11 not found, using installed 3.X
+    py -3 -m venv %VENV_DIR%
+    echo Python version is:
+    py -3 --version
 )
 
-if not exist ..\..\venv\Scripts\activate.bat (
+if not exist %VENV_DIR%\Scripts\activate.bat (
     echo Virtual environment not created successfully.
     exit /b 1
 )
-if not exist ..\..\venv\Scripts\python.exe (
+if not exist %VENV_DIR%\Scripts\python.exe (
     echo Python executable not found in the virtual environment.
+    echo Dependencies are not installed!
     exit /b 1
 )
 
-call ..\..\venv\Scripts\activate.bat
+call %VENV_DIR%\Scripts\activate.bat
 python -m ensurepip --upgrade
 python -m pip install pip-tools setuptools wheel
-REM call .\update_dependencies.cmd
 call .\install_dependencies.cmd
 call .\install_dev.cmd
 call .\check_java_jdk.cmd

--- a/ci/win32/create_venv.cmd
+++ b/ci/win32/create_venv.cmd
@@ -3,8 +3,27 @@ rem @echo off
 
 pushd .
 cd /D "%~dp0"
-py -3.11 -m venv ..\..\venv
+
+py --list | findstr /i /C:"3.11" 
+if %errorlevel% == 0 (
+    echo Python 3.11 found!.
+    py -3.11 -m venv ..\..\venv
+) else (
+    echo Python 3.11 not found, using installed 3.X version.
+    py -3 -m venv ..\..\venv
+)
+
+if not exist ..\..\venv\Scripts\activate.bat (
+    echo Virtual environment not created successfully.
+    exit /b 1
+)
+if not exist ..\..\venv\Scripts\python.exe (
+    echo Python executable not found in the virtual environment.
+    exit /b 1
+)
+
 call ..\..\venv\Scripts\activate.bat
+python -m ensurepip --upgrade
 python -m pip install pip-tools setuptools wheel
 REM call .\update_dependencies.cmd
 call .\install_dependencies.cmd

--- a/src/omotes_simulator_core/adapter/transforms/mappers.py
+++ b/src/omotes_simulator_core/adapter/transforms/mappers.py
@@ -14,6 +14,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Mapper classes."""
 
+import logging
+
 from esdl.esdl import Joint as esdl_junction
 
 from omotes_simulator_core.adapter.transforms.controller_mappers import (
@@ -29,6 +31,8 @@ from omotes_simulator_core.entities.heat_network import HeatNetwork
 from omotes_simulator_core.entities.network_controller import NetworkController
 from omotes_simulator_core.simulation.mappers.mappers import EsdlMapperAbstract
 from omotes_simulator_core.solver.network.network import Network
+
+logger = logging.getLogger(__name__)
 
 
 def replace_joint_in_connected_assets(
@@ -119,7 +123,7 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
 
         :param network: network to add the junctions to.
         :param py_assets_list: list of assets to connect to the junctions.
-        :param py_joint_dict: dictionary with all jints in the esdl.
+        :param py_joint_dict: dictionary with all joints in the esdl.
 
         :return: List of junctions that are created and connected to the assets.
         """
@@ -158,7 +162,6 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
         """Method to convert all assets from the esdl to a list of pyassets.
 
         This method loops over all assets in the esdl and converts them to pyassets.
-
         :param Network network: network to add the components to.
         :return: List of pyassets.
         """
@@ -167,8 +170,15 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
             # Esdl Junctions need to be skipped in this method, they are added in another method.
             if isinstance(esdl_asset.esdl_asset, esdl_junction):
                 continue
-            py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
-            network.add_existing_asset(py_assets_list[-1].solver_asset)
+            if esdl_asset.get_state() == "ENABLED":  # Only use asset if it is enabled.
+                py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
+                network.add_existing_asset(py_assets_list[-1].solver_asset)
+            else:
+                logger.warning(
+                    f"The state of {esdl_asset.get_name()} is set to {esdl_asset.get_state()}. "
+                    f"This asset will be ignored by the simulator.",
+                    extra={"esdl_object_id": esdl_asset.get_id()},
+                )
 
         return py_assets_list
 

--- a/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
+++ b/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
@@ -55,6 +55,14 @@ class EsdlAssetObject:
         """Get the id of the asset."""
         return str(self.esdl_asset.id)
 
+    def get_state(self) -> str:
+        """Get state of the asset.
+
+        The options for the asset's state are ENABLED, DISABLED and OPTIONAL. The simulator
+        will only use assets that have an ENABLED state.
+        """
+        return str(self.esdl_asset.state)
+
     def get_property(self, esdl_property_name: str, default_value: Any) -> Any:
         """Get property value from the esdl_asset based on the 'ESDL' name.
 

--- a/src/omotes_simulator_core/entities/esdl_object.py
+++ b/src/omotes_simulator_core/entities/esdl_object.py
@@ -71,12 +71,22 @@ class EsdlObject:
         """
         esdl_asset = self.energy_system_handler.get_by_id(asset_id)
 
-        connected_port_ids = []
+        connected_ports = []
+        connected_assets = []
         for esdl_port in esdl_asset.port:
             if esdl_port.id == port_id:
-                connected_port_ids = esdl_port.connectedTo
+                connected_ports = (
+                    esdl_port.connectedTo
+                )  # TODO: try to maybe only use assets that are enabled here.
                 break
-        if not connected_port_ids:
+
+        connected_assets = [
+            (port.energyasset.id, port.id)
+            for port in connected_ports
+            if str(port.energyasset.state) == "ENABLED"
+        ]
+
+        if not connected_ports or not connected_assets:
             raise ValueError(f"No connected assets found for asset: {asset_id} and port: {port_id}")
-        connected_assets = [(port.energyasset.id, port.id) for port in connected_port_ids]
+
         return connected_assets

--- a/src/omotes_simulator_core/solver/network/network.py
+++ b/src/omotes_simulator_core/solver/network/network.py
@@ -20,10 +20,12 @@ import numpy.typing as npt
 from omotes_simulator_core.solver.network.assets.base_asset import BaseAsset
 from omotes_simulator_core.solver.network.assets.boundary import BaseBoundary
 from omotes_simulator_core.solver.network.assets.fall_type import FallType
+from omotes_simulator_core.solver.network.assets.heat_transfer_asset import (
+    HeatTransferAsset,
+)
 from omotes_simulator_core.solver.network.assets.node import Node
 from omotes_simulator_core.solver.network.assets.production_asset import HeatBoundary
 from omotes_simulator_core.solver.network.assets.solver_pipe import SolverPipe
-from omotes_simulator_core.solver.network.assets.heat_transfer_asset import HeatTransferAsset
 
 
 class Network:


### PR DESCRIPTION
is available,  use default python 3 version otherwise

Only implemented on Windows,  this is not easily feasible on linux because of differences in installation paths (no easy 'py' launcher available)