### PR TITLE
283 use state of asset

### DIFF
--- a/src/omotes_simulator_core/adapter/transforms/mappers.py
+++ b/src/omotes_simulator_core/adapter/transforms/mappers.py
@@ -14,6 +14,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Mapper classes."""
 
+import logging
+
 from esdl.esdl import Joint as esdl_junction
 
 from omotes_simulator_core.adapter.transforms.controller_mappers import (
@@ -29,6 +31,8 @@ from omotes_simulator_core.entities.heat_network import HeatNetwork
 from omotes_simulator_core.entities.network_controller import NetworkController
 from omotes_simulator_core.simulation.mappers.mappers import EsdlMapperAbstract
 from omotes_simulator_core.solver.network.network import Network
+
+logger = logging.getLogger(__name__)
 
 
 def replace_joint_in_connected_assets(
@@ -169,6 +173,12 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
             if esdl_asset.get_state() == "ENABLED":  # Only use asset if it is enabled.
                 py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
                 network.add_existing_asset(py_assets_list[-1].solver_asset)
+            else:
+                logger.warning(
+                    f"The state of {esdl_asset.get_name()} is set to {esdl_asset.get_state()}. "
+                    f"This asset will be ignored by the simulator.",
+                    extra={"esdl_object_id": esdl_asset.get_id()},
+                )
 
         return py_assets_list
 

--- a/src/omotes_simulator_core/adapter/transforms/mappers.py
+++ b/src/omotes_simulator_core/adapter/transforms/mappers.py
@@ -119,7 +119,7 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
 
         :param network: network to add the junctions to.
         :param py_assets_list: list of assets to connect to the junctions.
-        :param py_joint_dict: dictionary with all jints in the esdl.
+        :param py_joint_dict: dictionary with all joints in the esdl.
 
         :return: List of junctions that are created and connected to the assets.
         """

--- a/src/omotes_simulator_core/adapter/transforms/mappers.py
+++ b/src/omotes_simulator_core/adapter/transforms/mappers.py
@@ -162,13 +162,15 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
         :param Network network: network to add the components to.
         :return: List of pyassets.
         """
+
         py_assets_list = []
-        for esdl_asset in self.esdl_object.get_all_assets_of_type("asset"):
+        for esdl_asset in self.esdl_object.get_all_assets_of_type("asset"): 
             # Esdl Junctions need to be skipped in this method, they are added in another method.
             if isinstance(esdl_asset.esdl_asset, esdl_junction):
                 continue
-            py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
-            network.add_existing_asset(py_assets_list[-1].solver_asset)
+            if esdl_asset.get_state() == "ENABLED": # Only use asset if it is enabled.
+                py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
+                network.add_existing_asset(py_assets_list[-1].solver_asset)
 
         return py_assets_list
 

--- a/src/omotes_simulator_core/adapter/transforms/mappers.py
+++ b/src/omotes_simulator_core/adapter/transforms/mappers.py
@@ -158,17 +158,15 @@ class EsdlEnergySystemMapper(EsdlMapperAbstract):
         """Method to convert all assets from the esdl to a list of pyassets.
 
         This method loops over all assets in the esdl and converts them to pyassets.
-
         :param Network network: network to add the components to.
         :return: List of pyassets.
         """
-
         py_assets_list = []
-        for esdl_asset in self.esdl_object.get_all_assets_of_type("asset"): 
+        for esdl_asset in self.esdl_object.get_all_assets_of_type("asset"):
             # Esdl Junctions need to be skipped in this method, they are added in another method.
             if isinstance(esdl_asset.esdl_asset, esdl_junction):
                 continue
-            if esdl_asset.get_state() == "ENABLED": # Only use asset if it is enabled.
+            if esdl_asset.get_state() == "ENABLED":  # Only use asset if it is enabled.
                 py_assets_list.append(EsdlAssetMapper.to_entity(esdl_asset))
                 network.add_existing_asset(py_assets_list[-1].solver_asset)
 

--- a/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
+++ b/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
@@ -54,6 +54,10 @@ class EsdlAssetObject:
     def get_id(self) -> str:
         """Get the id of the asset."""
         return str(self.esdl_asset.id)
+    
+    def get_state(self) -> str:
+        """Get state of the asset."""
+        return str(self.esdl_asset.state)
 
     def get_property(self, esdl_property_name: str, default_value: Any) -> Any:
         """Get property value from the esdl_asset based on the 'ESDL' name.

--- a/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
+++ b/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
@@ -54,7 +54,7 @@ class EsdlAssetObject:
     def get_id(self) -> str:
         """Get the id of the asset."""
         return str(self.esdl_asset.id)
-    
+
     def get_state(self) -> str:
         """Get state of the asset."""
         return str(self.esdl_asset.state)

--- a/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
+++ b/src/omotes_simulator_core/entities/assets/esdl_asset_object.py
@@ -56,7 +56,11 @@ class EsdlAssetObject:
         return str(self.esdl_asset.id)
 
     def get_state(self) -> str:
-        """Get state of the asset."""
+        """Get state of the asset.
+
+        The options for the asset's state are ENABLED, DISABLED and OPTIONAL. The simulator
+        will only use assets that have an ENABLED state.
+        """
         return str(self.esdl_asset.state)
 
     def get_property(self, esdl_property_name: str, default_value: Any) -> Any:

--- a/src/omotes_simulator_core/entities/esdl_object.py
+++ b/src/omotes_simulator_core/entities/esdl_object.py
@@ -85,12 +85,7 @@ class EsdlObject:
             for port in connected_ports
             if str(port.energyasset.state) == "ENABLED"
         ]
-        # for port in connected_ports:
-        #     port_asset = port.energyasset
-        #     if (
-        #         str(port_asset.state) == "ENABLED"
-        #     ):  # Check if the asset the port is connected to is enabled.
-        #         connected_assets.append((port_asset.id, port.id))
+
         if not connected_ports or not connected_assets:
             raise ValueError(f"No connected assets found for asset: {asset_id} and port: {port_id}")
 

--- a/src/omotes_simulator_core/entities/esdl_object.py
+++ b/src/omotes_simulator_core/entities/esdl_object.py
@@ -79,12 +79,18 @@ class EsdlObject:
                     esdl_port.connectedTo
                 )  # TODO: try to maybe only use assets that are enabled here.
                 break
-        for port in connected_ports:
-            port_asset = port.energyasset
-            if (
-                str(port_asset.state) == "ENABLED"
-            ):  # Check if the asset the port is connected to is enabled.
-                connected_assets.append((port_asset.id, port.id))
+
+        connected_assets = [
+            (port.energyasset.id, port.id)
+            for port in connected_ports
+            if str(port.energyasset.state) == "ENABLED"
+        ]
+        # for port in connected_ports:
+        #     port_asset = port.energyasset
+        #     if (
+        #         str(port_asset.state) == "ENABLED"
+        #     ):  # Check if the asset the port is connected to is enabled.
+        #         connected_assets.append((port_asset.id, port.id))
         if not connected_ports or not connected_assets:
             raise ValueError(f"No connected assets found for asset: {asset_id} and port: {port_id}")
 

--- a/src/omotes_simulator_core/entities/esdl_object.py
+++ b/src/omotes_simulator_core/entities/esdl_object.py
@@ -75,11 +75,15 @@ class EsdlObject:
         connected_assets = []
         for esdl_port in esdl_asset.port:
             if esdl_port.id == port_id:
-                connected_ports = esdl_port.connectedTo #TODO: try to maybe only use assets that are enabled here.
+                connected_ports = (
+                    esdl_port.connectedTo
+                )  # TODO: try to maybe only use assets that are enabled here.
                 break
         for port in connected_ports:
             port_asset = port.energyasset
-            if str(port_asset.state) == 'ENABLED': # Check if the asset the port is connected to is enabled.
+            if (
+                str(port_asset.state) == "ENABLED"
+            ):  # Check if the asset the port is connected to is enabled.
                 connected_assets.append((port_asset.id, port.id))
         if not connected_ports or not connected_assets:
             raise ValueError(f"No connected assets found for asset: {asset_id} and port: {port_id}")

--- a/src/omotes_simulator_core/entities/esdl_object.py
+++ b/src/omotes_simulator_core/entities/esdl_object.py
@@ -71,12 +71,17 @@ class EsdlObject:
         """
         esdl_asset = self.energy_system_handler.get_by_id(asset_id)
 
-        connected_port_ids = []
+        connected_ports = []
+        connected_assets = []
         for esdl_port in esdl_asset.port:
             if esdl_port.id == port_id:
-                connected_port_ids = esdl_port.connectedTo
+                connected_ports = esdl_port.connectedTo #TODO: try to maybe only use assets that are enabled here.
                 break
-        if not connected_port_ids:
+        for port in connected_ports:
+            port_asset = port.energyasset
+            if str(port_asset.state) == 'ENABLED': # Check if the asset the port is connected to is enabled.
+                connected_assets.append((port_asset.id, port.id))
+        if not connected_ports or not connected_assets:
             raise ValueError(f"No connected assets found for asset: {asset_id} and port: {port_id}")
-        connected_assets = [(port.energyasset.id, port.id) for port in connected_port_ids]
+
         return connected_assets

--- a/src/omotes_simulator_core/solver/network/network.py
+++ b/src/omotes_simulator_core/solver/network/network.py
@@ -20,10 +20,12 @@ import numpy.typing as npt
 from omotes_simulator_core.solver.network.assets.base_asset import BaseAsset
 from omotes_simulator_core.solver.network.assets.boundary import BaseBoundary
 from omotes_simulator_core.solver.network.assets.fall_type import FallType
+from omotes_simulator_core.solver.network.assets.heat_transfer_asset import (
+    HeatTransferAsset,
+)
 from omotes_simulator_core.solver.network.assets.node import Node
 from omotes_simulator_core.solver.network.assets.production_asset import HeatBoundary
 from omotes_simulator_core.solver.network.assets.solver_pipe import SolverPipe
-from omotes_simulator_core.solver.network.assets.heat_transfer_asset import HeatTransferAsset
 
 
 class Network:


### PR DESCRIPTION
The simulator now only uses assets that have the state of "ENABLED" in the esdl. When converting the esdl to py_assets, the mapper now excludes assets with the "DISABLED" and "OPTIONAL" states. 
By default, and already before this PR, the simulator fails when trying to run an esdl with disconnected ports. The code stops running and returns an error fo the type: 
ValueError: No connected assets found for asset: Pipe1 and port: a9793a5e-df4f-4795-8079-015dfaf57f82
When using an esdl with disabled or optional assets, it can result in a network with disconnected ports. The code was updated here to result in the same behavior as described above. Modifications were needed in the way joints are created.