### PR TITLE
Small fix to the priority strategy.

### DIFF
--- a/src/omotes_simulator_core/entities/network_controller.py
+++ b/src/omotes_simulator_core/entities/network_controller.py
@@ -95,7 +95,7 @@ class NetworkController(NetworkControllerAbstract):
         highest priority.
         """
         # Check to see if any of the producers has no priority assigned, if so set it to the lowest.
-        lowest_priority = min(
+        lowest_priority = max(
             [producer.priority for producer in self.producers if producer.priority is not None]
         )
         # For assets that have no priority assingned, give them the lowest priority.


### PR DESCRIPTION
This is a very small PR to fix a mistake I noticed in the priority strategy functionality. It used to assign assets with no priority set the lowest possible numerical value. This is incorrect, the lowest priority is defined as the asset with the highest priority numerical value. I fixed the line where this happens and now works as intended.