### PR TITLE
fix pipe mapper message for diameter

### DIFF
--- a/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
+++ b/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
@@ -17,6 +17,7 @@
 import logging
 from typing import Any
 
+import esdl
 import numpy as np
 from esdl.edr.client import EDRClient
 
@@ -112,8 +113,9 @@ class EsdlAssetPipeMapper(EsdlMapperAbstract):
             if inner_diameter != 0:
                 return inner_diameter
 
-        dn_diameter = esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter)
-        if dn_diameter is PIPE_DEFAULTS.diameter:
+        # diameter is an esdl.PipeDiameterEnum; VALUE_SPECIFIED means no DN size is given.
+        dn_diameter = esdl_asset.esdl_asset.diameter
+        if dn_diameter == esdl.PipeDiameterEnum.VALUE_SPECIFIED:
             return PIPE_DEFAULTS.diameter
 
         esdl_object = EsdlAssetPipeMapper._get_esdl_object_from_edr(dn_diameter.name, schedule)

--- a/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
+++ b/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
@@ -107,20 +107,17 @@ class EsdlAssetPipeMapper(EsdlMapperAbstract):
         # TODO add method to get schedule from esdl if it becomes available.
         schedule = PIPE_DEFAULTS.default_schedule
 
-        has_inner_diameter = esdl_asset.esdl_asset.eIsSet("innerDiameter")
-        has_dn_diameter = esdl_asset.esdl_asset.eIsSet("diameter")
-
-        if not has_inner_diameter and not has_dn_diameter:
-            return float(esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter))
-
-        if has_inner_diameter:
+        if esdl_asset.esdl_asset.eIsSet("innerDiameter"):
             return float(esdl_asset.get_property("innerDiameter", PIPE_DEFAULTS.diameter))
 
         dn_diameter = esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter)
+        if dn_diameter is PIPE_DEFAULTS.diameter:
+            return PIPE_DEFAULTS.diameter
+
         esdl_object = EsdlAssetPipeMapper._get_esdl_object_from_edr(dn_diameter.name, schedule)
         logger.info(
             f"Property innerDiameter is not set for: {esdl_asset.get_name()}, "
-            f"Schedule S1 is assumed for retrieval of pipe diameter from EDR list."
+            f"Schedule S1 is assumed for retrieval of pipe inner diameter from EDR list."
         )
         return float(esdl_object.innerDiameter)
 

--- a/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
+++ b/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
@@ -13,6 +13,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Module containing the Esdl to Pipe asset mapper class."""
+
 import logging
 from typing import Any
 
@@ -102,26 +103,26 @@ class EsdlAssetPipeMapper(EsdlMapperAbstract):
         the insulation schedule must be provided; in this case, it is assumed to be 1.
 
         """
-        inner_diameter = esdl_asset.get_property("innerDiameter", 0)
-        dn_diameter = esdl_asset.get_property("diameter", None)
         # Use default schedule since schedule is not a valid ESDL Pipe attribute
         # TODO add method to get schedule from esdl if it becomes available.
         schedule = PIPE_DEFAULTS.default_schedule
 
-        if inner_diameter == 0:
-            if dn_diameter is not None:
-                esdl_object = EsdlAssetPipeMapper._get_esdl_object_from_edr(
-                    dn_diameter.name, schedule
-                )
-                logger.info(
-                    f"Property innerDiameter is not set for: {esdl_asset.get_name()}, "
-                    f"Schedule S1 is assumed for retrieval of pipe diameter from EDR list."
-                )
-                return float(esdl_object.innerDiameter)
-            else:
-                return PIPE_DEFAULTS.diameter
-        else:
-            return float(inner_diameter)
+        has_inner_diameter = esdl_asset.esdl_asset.eIsSet("innerDiameter")
+        has_dn_diameter = esdl_asset.esdl_asset.eIsSet("diameter")
+
+        if not has_inner_diameter and not has_dn_diameter:
+            return float(esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter))
+
+        if has_inner_diameter:
+            return float(esdl_asset.get_property("innerDiameter", PIPE_DEFAULTS.diameter))
+
+        dn_diameter = esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter)
+        esdl_object = EsdlAssetPipeMapper._get_esdl_object_from_edr(dn_diameter.name, schedule)
+        logger.info(
+            f"Property innerDiameter is not set for: {esdl_asset.get_name()}, "
+            f"Schedule S1 is assumed for retrieval of pipe diameter from EDR list."
+        )
+        return float(esdl_object.innerDiameter)
 
     @staticmethod
     def _get_esdl_object_from_edr(

--- a/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
+++ b/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
@@ -108,7 +108,9 @@ class EsdlAssetPipeMapper(EsdlMapperAbstract):
         schedule = PIPE_DEFAULTS.default_schedule
 
         if esdl_asset.esdl_asset.eIsSet("innerDiameter"):
-            return float(esdl_asset.get_property("innerDiameter", PIPE_DEFAULTS.diameter))
+            inner_diameter = float(esdl_asset.get_property("innerDiameter", PIPE_DEFAULTS.diameter))
+            if inner_diameter != 0:
+                return inner_diameter
 
         dn_diameter = esdl_asset.get_property("diameter", PIPE_DEFAULTS.diameter)
         if dn_diameter is PIPE_DEFAULTS.diameter:

--- a/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
+++ b/src/omotes_simulator_core/adapter/transforms/esdl_asset_mappers/pipe_mapper.py
@@ -116,14 +116,22 @@ class EsdlAssetPipeMapper(EsdlMapperAbstract):
         # diameter is an esdl.PipeDiameterEnum; VALUE_SPECIFIED means no DN size is given.
         dn_diameter = esdl_asset.esdl_asset.diameter
         if dn_diameter == esdl.PipeDiameterEnum.VALUE_SPECIFIED:
+            logger.warning(
+                f"Property innerDiameter is not set for: {esdl_asset.get_name()}. "
+                f"Returning default value: {PIPE_DEFAULTS.diameter} m.",
+                extra={"esdl_object_id": esdl_asset.get_id()},
+            )
             return PIPE_DEFAULTS.diameter
 
         esdl_object = EsdlAssetPipeMapper._get_esdl_object_from_edr(dn_diameter.name, schedule)
-        logger.info(
-            f"Property innerDiameter is not set for: {esdl_asset.get_name()}, "
-            f"Schedule S1 is assumed for retrieval of pipe inner diameter from EDR list."
+        inner_diameter = float(esdl_object.innerDiameter)
+        logger.warning(
+            f"Property innerDiameter is not set for: {esdl_asset.get_name()}. "
+            f"Schedule {schedule.name} is assumed for retrieval of pipe inner diameter from the "
+            f"EDR list.Returning value: {inner_diameter} m.",
+            extra={"esdl_object_id": esdl_asset.get_id()},
         )
-        return float(esdl_object.innerDiameter)
+        return inner_diameter
 
     @staticmethod
     def _get_esdl_object_from_edr(

--- a/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
+++ b/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
@@ -20,6 +20,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import esdl
+
 from omotes_simulator_core.adapter.transforms.esdl_asset_mappers.pipe_mapper import (
     EsdlAssetPipeMapper,
 )
@@ -157,11 +159,10 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
         def mock_get_property(key, default=None):
             if key == "innerDiameter":
                 return 0
-            if key == "diameter":
-                return dn_mock
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.diameter = dn_mock
         esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key == "diameter"
         edr_object_mock = Mock()
         edr_object_mock.innerDiameter = 0.42
@@ -185,11 +186,10 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
         def mock_get_property(key, default=None):
             if key == "innerDiameter":
                 return 0
-            if key == "diameter":
-                return dn_mock
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.diameter = dn_mock
         esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key in (
             "innerDiameter",
             "diameter",
@@ -207,7 +207,7 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             self.assertEqual(diameter, 0.1273)
 
     def test_get_diameter_default_when_none_provided(self):
-        """Returns default diameter when both innerDiameter is 0 and diameter is None."""
+        """Returns default diameter when innerDiameter is 0 and diameter is VALUE_SPECIFIED."""
         # Arrange
         esdl_asset_mock = Mock()
 
@@ -217,6 +217,7 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.diameter = esdl.PipeDiameterEnum.VALUE_SPECIFIED
         esdl_asset_mock.esdl_asset.eIsSet.return_value = False
 
         # Act
@@ -252,11 +253,10 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
         def mock_get_property(key, default=None):
             if key == "innerDiameter":
                 return 0
-            if key == "diameter":
-                return dn_mock
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.diameter = dn_mock
         esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key == "diameter"
         edr_object_mock = Mock()
         edr_object_mock.innerDiameter = 0.08

--- a/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
+++ b/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
@@ -14,6 +14,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Test pipe mapper."""
+
 import typing
 import unittest
 from pathlib import Path
@@ -138,6 +139,7 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key == "innerDiameter"
 
         # Act
         diameter = EsdlAssetPipeMapper._get_diameter(esdl_asset_mock)
@@ -160,6 +162,7 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key == "diameter"
         edr_object_mock = Mock()
         edr_object_mock.innerDiameter = 0.42
 
@@ -180,11 +183,10 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
         def mock_get_property(key, default=None):
             if key == "innerDiameter":
                 return 0
-            if key == "diameter":
-                return None
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.eIsSet.return_value = False
 
         # Act
         diameter = EsdlAssetPipeMapper._get_diameter(esdl_asset_mock)
@@ -224,6 +226,7 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             return default
 
         esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key == "diameter"
         edr_object_mock = Mock()
         edr_object_mock.innerDiameter = 0.08
 

--- a/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
+++ b/unit_test/adapters/transforms/esdl_asset_mappers/test_esdl_asset_pipe_mapper.py
@@ -175,6 +175,37 @@ class TestEsdlAssetPipeMapper(unittest.TestCase):
             # Assert
             self.assertEqual(diameter, 0.42)
 
+    def test_get_diameter_with_inner_diameter_zero_uses_edr(self):
+        """Falls back to EDR when innerDiameter is set to 0 but a DN diameter is provided."""
+        # Arrange
+        esdl_asset_mock = Mock()
+        dn_mock = Mock()
+        dn_mock.name = "DN125"
+
+        def mock_get_property(key, default=None):
+            if key == "innerDiameter":
+                return 0
+            if key == "diameter":
+                return dn_mock
+            return default
+
+        esdl_asset_mock.get_property = mock_get_property
+        esdl_asset_mock.esdl_asset.eIsSet.side_effect = lambda key: key in (
+            "innerDiameter",
+            "diameter",
+        )
+        edr_object_mock = Mock()
+        edr_object_mock.innerDiameter = 0.1273
+
+        with patch.object(
+            EsdlAssetPipeMapper, "_get_esdl_object_from_edr", return_value=edr_object_mock
+        ):
+            # Act
+            diameter = EsdlAssetPipeMapper._get_diameter(esdl_asset_mock)
+
+            # Assert
+            self.assertEqual(diameter, 0.1273)
+
     def test_get_diameter_default_when_none_provided(self):
         """Returns default diameter when both innerDiameter is 0 and diameter is None."""
         # Arrange


### PR DESCRIPTION
small fix for the messages shown in the terminal for the diameter. Currently messages shows value None is used if default value is used as diameter. Also, because the message is raised by get_property method, it doesnt indicate correctly if its the inner diameter or diameter which is missing.